### PR TITLE
Use 'investigating' incidents also as current

### DIFF
--- a/views.go
+++ b/views.go
@@ -237,7 +237,7 @@ func currentIncident(incidents []Incident) *Incident {
 	// assumes that incidents come in sorted most recent first
 	now := time.Now()
 	for _, incident := range incidents {
-		if incident.End.After(now) || incident.Status == "outage" {
+		if incident.End.After(now) || incident.Status == "outage" || incident.Status == "investigating" {
 			return &incident
 		}
 	}


### PR DESCRIPTION
Currently on ctlstatus.appspot.com it says there's "No known issues at
this time" even though the 'staging sites inaccessible' incident hasn't
ended yet. This doesn't seem right so I've made this change.
